### PR TITLE
Optimize for small numbers of arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,33 @@
 # asarg
-Executes the supplied function with this as an argument
+Executes the supplied function with `this` as the first argument. Example:
+
+```js
+const asarg = require('asarg')
+
+const add = asarg( ( x, y ) => x + y )
+assert.equal(add.call(1, 2), 3)
+```
+
+Note that `this` is kept unmodified.
+
+```js
+const asarg = require('asarg')
+
+const add = asarg(function ( _, y ){ return this + y } )
+assert.equal(add.call(1, 2), 3)
+```
+
+It also works very well with the [function bind proposal](https://github.com/zenparsing/es-function-bind):
+
+```js
+const asarg = require('asarg')
+
+const concat = asarg( lists => [].concat( ...lists ) )
+assert.deepEqual(
+    [ [ 1, 2 ], [ 3 ], [ 4, 5, 6 ] ]::concat(),
+    [ 1, 2, 3, 4, 5, 6 ] )
+```
+
+## License
+
+MIT

--- a/asarg.js
+++ b/asarg.js
@@ -1,10 +1,35 @@
 function asarg( fn ){
-	return function(){
-		var subject = this
-		var input   = Array.prototype.slice.call( arguments )
-		var args    = [ subject ].concat( input )
+	'use strict'
 
-		return fn.apply( subject, args )
+	return function(){
+		// Optimize the common case of a low-ish number of arguments. Engines
+		// are very good at optimizing function calls with consistent numbers of
+		// arguments.
+		switch (arguments.length) {
+		case 0: return fn.call( this, this )
+		case 1: return fn.call( this, this, arguments[ 0 ] )
+		case 2: return fn.call( this, this, arguments[ 0 ], arguments[ 1 ] )
+
+		case 3:
+			return fn.call( this, this,
+				arguments[ 0 ],
+				arguments[ 1 ],
+				arguments[ 2 ] )
+
+		case 4:
+			return fn.call( this, this,
+				arguments[ 0 ],
+				arguments[ 1 ],
+				arguments[ 2 ],
+				arguments[ 3 ] )
+
+		default:
+			var subject = this
+			var input   = Array.prototype.slice.call( arguments )
+			var args    = [ this ].concat( input )
+
+			return fn.apply( this, args )
+		}
 	}
 }
 

--- a/tests.js
+++ b/tests.js
@@ -3,10 +3,7 @@ import as   from './asarg'
 
 test( 'Exposes this as the first argument', test => {
 	test.equals(
-		as( arg =>
-			arg
-		).call( this ),
-
+		as( arg => arg ).call( this ),
 		this
 	)
 
@@ -15,23 +12,108 @@ test( 'Exposes this as the first argument', test => {
 
 test( 'Retains this reference', test => {
 	test.equals(
-		as( arg =>
-			this
-		).call( this ),
-
+		as( function ( arg ){ return this } ).call( this ),
 		this
 	)
 
 	test.end()
 } )
 
-test( 'Retains arguments shifted once to the right', function( test ){
-	const inputs = [ 'foo', 'bar' ]
+test( 'Retains 1 argument shifted once to the right', function( test ){
+	const inputs = [ 'foo' ]
+	const self = this
 
-	as( ( ...args ) => {
+	as( function ( ...args ){
+		test.equals( self, this )
+		test.equals( self, args[ 0 ] )
 		test.equals( inputs[ 0 ], args[ 1 ] )
 
+		test.end()
+	} ).apply( this, inputs )
+} )
+
+test( 'Retains 2 arguments shifted once to the right', function( test ){
+	const inputs = [ 'foo', 'bar' ]
+	const self = this
+
+	as( function ( ...args ){
+		test.equals( self, this )
+		test.equals( self, args[ 0 ] )
+		test.equals( inputs[ 0 ], args[ 1 ] )
 		test.equals( inputs[ 1 ], args[ 2 ] )
+
+		test.end()
+	} ).apply( this, inputs )
+} )
+
+test( 'Retains 3 arguments shifted once to the right', function( test ){
+	const inputs = [ 'foo', 'bar', 'baz' ]
+	const self = this
+
+	as( function ( ...args ){
+		test.equals( self, this )
+		test.equals( self, args[ 0 ] )
+		test.equals( inputs[ 0 ], args[ 1 ] )
+		test.equals( inputs[ 1 ], args[ 2 ] )
+		test.equals( inputs[ 2 ], args[ 3 ] )
+
+		test.end()
+	} ).apply( this, inputs )
+} )
+
+test( 'Retains 4 arguments shifted once to the right', function( test ){
+	const inputs = [ 'foo', 'bar', 'baz', 'spam' ]
+	const self = this
+
+	as( function ( ...args ){
+		test.equals( self, this )
+		test.equals( self, args[ 0 ] )
+		test.equals( inputs[ 0 ], args[ 1 ] )
+		test.equals( inputs[ 1 ], args[ 2 ] )
+		test.equals( inputs[ 2 ], args[ 3 ] )
+		test.equals( inputs[ 3 ], args[ 4 ] )
+
+		test.end()
+	} ).apply( this, inputs )
+} )
+
+test( 'Retains 5 arguments shifted once to the right', function( test ){
+	const inputs = [ 'foo', 'bar', 'baz', 'spam', 'eggs' ]
+	const self = this
+
+	as( function ( ...args ){
+		test.equals( self, this )
+		test.equals( self, args[ 0 ] )
+		test.equals( inputs[ 0 ], args[ 1 ] )
+		test.equals( inputs[ 1 ], args[ 2 ] )
+		test.equals( inputs[ 2 ], args[ 3 ] )
+		test.equals( inputs[ 3 ], args[ 4 ] )
+		test.equals( inputs[ 4 ], args[ 5 ] )
+
+		test.end()
+	} ).apply( this, inputs )
+} )
+
+test( 'Retains 10 arguments shifted once to the right', function( test ){
+	const inputs = [
+		'foo', 'bar', 'baz', 'spam', 'eggs',
+		'one', 'two', 'three', 'four', 'five'
+	]
+	const self = this
+
+	as( function ( ...args ){
+		test.equals( self, this )
+		test.equals( self, args[ 0 ] )
+		test.equals( inputs[ 0 ], args[ 1 ] )
+		test.equals( inputs[ 1 ], args[ 2 ] )
+		test.equals( inputs[ 2 ], args[ 3 ] )
+		test.equals( inputs[ 3 ], args[ 4 ] )
+		test.equals( inputs[ 4 ], args[ 5 ] )
+		test.equals( inputs[ 5 ], args[ 6 ] )
+		test.equals( inputs[ 6 ], args[ 7 ] )
+		test.equals( inputs[ 7 ], args[ 8 ] )
+		test.equals( inputs[ 8 ], args[ 9 ] )
+		test.equals( inputs[ 9 ], args[ 10 ] )
 
 		test.end()
 	} ).apply( this, inputs )


### PR DESCRIPTION
I also have a tagalong commit to expand the README to include license/examples (and reference the related [ES function bind proposal](https://github.com/zenparsing/es-function-bind)), but it's easy to remove, if you would rather leave that out.
